### PR TITLE
Add support for overrides and application builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/helpers/src/main/java/com/linkedin/plugin/BindingOverride.java
+++ b/helpers/src/main/java/com/linkedin/plugin/BindingOverride.java
@@ -1,0 +1,15 @@
+package com.linkedin.plugin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BindingOverride {
+  Class target();
+  Class implementation();
+  String stringQualifier() default "";
+  Class annotationQualifier() default Object.class;
+}

--- a/helpers/src/main/java/com/linkedin/plugin/NGTestsBase.java
+++ b/helpers/src/main/java/com/linkedin/plugin/NGTestsBase.java
@@ -118,9 +118,16 @@ public abstract class NGTestsBase implements IHookable {
     }
 
     protected boolean isDefined(Class clz) {
-      return !Object.class.equals(clz);
+      return clz != null && !Object.class.equals(clz);
     }
 
+    protected <T> T instantiate(Class<?> clazz) {
+      try {
+        return (T) clazz.newInstance();
+      } catch (Exception e) {
+        throw new RuntimeException("Unable to instantiate class " + clazz);
+      }
+    }
 
     private Stream<Binding<?>> toStream(WithOverrides overrides) {
       return Optional.ofNullable(overrides).map(o -> Arrays.stream(o.value()).map(this::toBinding)).orElse(Stream.empty());
@@ -167,6 +174,7 @@ public abstract class NGTestsBase implements IHookable {
     private Class testClass() {
       return itr.getTestClass().getRealClass();
     }
+
 
   }
 }

--- a/helpers/src/main/java/com/linkedin/plugin/WithOverrides.java
+++ b/helpers/src/main/java/com/linkedin/plugin/WithOverrides.java
@@ -1,0 +1,12 @@
+package com.linkedin.plugin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithOverrides {
+  BindingOverride[] value() default {};
+}

--- a/helpers/src/main/java/com/linkedin/plugin/WithPlugins.java
+++ b/helpers/src/main/java/com/linkedin/plugin/WithPlugins.java
@@ -1,11 +1,11 @@
 // Copyright 2012 LinkedIn
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.annotation.ElementType;
 
-// TODO: deprecate or delete this when we figure out dependency injection?
+/**
+ * @deprecated Use dependency injection with Play 2.4 instead of plugins
+ */
+@Deprecated
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface WithPlugins {

--- a/helpers/src/main/java/com/linkedin/plugin/j/FakeApplicationFactory.java
+++ b/helpers/src/main/java/com/linkedin/plugin/j/FakeApplicationFactory.java
@@ -1,0 +1,12 @@
+package com.linkedin.plugin.j;
+
+import play.Application;
+
+/**
+ * Knows how to build applications using the data that is available from annotations.
+ */
+public interface FakeApplicationFactory {
+
+  Application buildApplication(FakeApplicationFactoryArgs args);
+
+}

--- a/helpers/src/main/java/com/linkedin/plugin/j/FakeApplicationFactoryArgs.java
+++ b/helpers/src/main/java/com/linkedin/plugin/j/FakeApplicationFactoryArgs.java
@@ -1,0 +1,57 @@
+package com.linkedin.plugin.j;
+
+import play.GlobalSettings;
+import play.api.inject.Binding;
+import play.inject.guice.GuiceBuilder;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeApplicationFactoryArgs {
+  private final File _path;
+  private final Optional<Class<? extends GuiceBuilder>> _builderClass;
+  private final Optional<GlobalSettings> _global;
+  private final List<Binding<?>> _overrides;
+  private final Map<String, Object> _config;
+  private final List<String> _plugins;
+
+  public FakeApplicationFactoryArgs(File path,
+                                    Optional<Class<? extends GuiceBuilder>> builderClass,
+                                    Optional<GlobalSettings> global,
+                                    List<Binding<?>> overrides,
+                                    Map<String, Object> config,
+                                    List<String> plugins) {
+    _path = path;
+    _builderClass = builderClass;
+    _global = global;
+    _overrides = overrides;
+    _config = config;
+    _plugins = plugins;
+  }
+
+  public File getPath() {
+    return _path;
+  }
+
+  public Optional<Class<? extends GuiceBuilder>> getBuilderClass() {
+    return _builderClass;
+  }
+
+  public Optional<GlobalSettings> getGlobal() {
+    return _global;
+  }
+
+  public List<Binding<?>> getOverrides() {
+    return _overrides;
+  }
+
+  public Map<String, Object> getConfig() {
+    return _config;
+  }
+
+  public List<String> getPlugins() {
+    return _plugins;
+  }
+}

--- a/helpers/src/main/java/com/linkedin/plugin/j/FakeApplicationFactoryImpl.java
+++ b/helpers/src/main/java/com/linkedin/plugin/j/FakeApplicationFactoryImpl.java
@@ -1,0 +1,58 @@
+package com.linkedin.plugin.j;
+
+import play.Application;
+import play.Environment;
+import play.GlobalSettings;
+import play.Mode;
+import play.api.inject.Binding;
+import play.api.inject.package$;
+import play.inject.guice.GuiceApplicationBuilder;
+import play.inject.guice.GuiceBuilder;
+import play.test.FakeApplication;
+import play.test.Helpers;
+
+/**
+ * Default implementation for building an Application. If a builder isn't specified and no overrides are present the Play
+ * FakeApplication is used. Otherwise a builder is used. Using @WithPlugins and a builder or overrides isn't supported.
+ */
+public class FakeApplicationFactoryImpl implements FakeApplicationFactory {
+  @Override
+  public Application buildApplication(FakeApplicationFactoryArgs args) {
+    return shouldUseBuilder(args) ? buildFromBuilder(args) : buildFromFakeApp(args);
+  }
+
+  protected boolean shouldUseBuilder(FakeApplicationFactoryArgs args) {
+    return args.getBuilderClass().isPresent() || !args.getOverrides().isEmpty();
+  }
+
+  protected Application buildFromFakeApp(FakeApplicationFactoryArgs args) {
+    return new FakeApplication(args.getPath(), Helpers.class.getClassLoader(), args.getConfig(), args.getPlugins(), args.getGlobal().orElse(null));
+  }
+
+  protected Application buildFromBuilder(FakeApplicationFactoryArgs args) {
+    Class<? extends GuiceBuilder> builderClass = args.getBuilderClass().orElse(GuiceApplicationBuilder.class);
+    GuiceBuilder builder;
+    try {
+      builder = builderClass.newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to instantiate application builder " + builderClass, e);
+    }
+    if (!args.getPlugins().isEmpty()) {
+      throw new RuntimeException("Using plugins isn't supported when using binding overrides or a GuiceBuilder.");
+    }
+
+    builder = (GuiceBuilder) builder.in(new Environment(args.getPath(), Helpers.class.getClassLoader(), Mode.TEST));
+    builder = (GuiceBuilder) builder.configure(args.getConfig());
+    if (args.getGlobal().isPresent()) {
+      GlobalSettings global = args.getGlobal().get();
+      if (builder instanceof GuiceApplicationBuilder) {
+        builder = ((GuiceApplicationBuilder) builder).global(global);
+      } else {
+        play.api.GlobalSettings scalaGlobal = new play.core.j.JavaGlobalSettingsAdapter(global);
+        builder = (GuiceBuilder) builder.bindings(package$.MODULE$.bind(play.api.GlobalSettings.class).toInstance(scalaGlobal));
+      }
+    }
+    builder = (GuiceBuilder) builder.overrides(args.getOverrides().toArray(new Binding[args.getOverrides().size()]));
+    return builder.injector().instanceOf(Application.class);
+  }
+}

--- a/helpers/src/main/java/com/linkedin/plugin/j/NGTests.java
+++ b/helpers/src/main/java/com/linkedin/plugin/j/NGTests.java
@@ -17,13 +17,21 @@ import com.linkedin.plugin.NGTestsBase;
 import org.testng.IHookCallBack;
 import org.testng.IHookable;
 import org.testng.ITestResult;
-import play.libs.F;
+import play.Application;
+import play.Environment;
+import play.GlobalSettings;
+import play.Mode;
+import play.api.inject.Binding;
+import play.api.inject.package$;
+import play.inject.guice.GuiceApplicationBuilder;
+import play.inject.guice.GuiceBuilder;
 import play.test.FakeApplication;
 import play.test.Helpers;
 import play.test.TestBrowser;
 import play.test.TestServer;
 
 import java.io.File;
+import java.util.List;
 
 import static play.test.Helpers.HTMLUNIT;
 
@@ -38,24 +46,58 @@ public class NGTests extends NGTestsBase implements IHookable {
       super(testResult, WithFakeApplication.class, WithTestServer.class);
     }
 
-    private FakeApplication buildFakeApplication(WithFakeApplication fa) {
-      if (fa != null) {
-        String path = fa.path();
-        Object globalSettings = null;
-        if (! Object.class.equals(fa.withGlobal())) {
-          try {
-            globalSettings = fa.withGlobal().newInstance();
-          } catch (Throwable e) {
-            throw new RuntimeException(e);
-          }
-        }
-        return new FakeApplication(new File(path), Helpers.class.getClassLoader(), getConf(), getPlugins(), (play.GlobalSettings) globalSettings);
+    private Application buildFakeApplication(WithFakeApplication fa) {
+      if (fa == null) {
+        return null;
       }
-      return null;
+      String path = fa.path();
+      GlobalSettings globalSettings = null;
+      if (isDefined(fa.withGlobal())) {
+        try {
+          globalSettings = (GlobalSettings) fa.withGlobal().newInstance();
+        } catch (Throwable e) {
+          throw new RuntimeException(e);
+        }
+      }
+      List<Binding<?>> overrides = getOverrides();
+      if (isDefined(fa.guiceBuilder()) || !overrides.isEmpty()) {
+        Class builderClass = Object.class.equals(fa.guiceBuilder()) ? GuiceApplicationBuilder.class : fa.guiceBuilder();
+        return buildFromBuilder(new File(path), globalSettings, builderClass, overrides);
+      }
+
+      return new FakeApplication(new File(path), Helpers.class.getClassLoader(), getConf(), getPlugins(), globalSettings);
+    }
+
+    /**
+     * Build from a 2.4 Builder instead of using FakeApplication
+     */
+    private Application buildFromBuilder(File path, GlobalSettings globalSettings, Class<?> builderClass, List<Binding<?>> overrides) {
+      GuiceBuilder builder;
+      try {
+        builder = (GuiceBuilder) builderClass.newInstance();
+      } catch (Exception e) {
+        throw new RuntimeException("Unable to instantiate application builder " + builderClass, e);
+      }
+      if (!getPlugins().isEmpty()) {
+        throw new RuntimeException("Using plugins isn't supported when using binding overrides or a GuiceBuilder.");
+      }
+
+      builder = (GuiceBuilder) builder.in(new Environment(path, Helpers.class.getClassLoader(), Mode.TEST));
+      builder = (GuiceBuilder) builder.configure(getConf());
+      if (globalSettings != null) {
+        if (builder instanceof GuiceApplicationBuilder) {
+          builder = ((GuiceApplicationBuilder) builder).global(globalSettings);
+        } else {
+          play.api.GlobalSettings scalaGlobal = new play.core.j.JavaGlobalSettingsAdapter(globalSettings);
+          builder = (GuiceBuilder) builder.bindings(package$.MODULE$.bind(play.api.GlobalSettings.class).toInstance(scalaGlobal));
+        }
+      }
+      builder = (GuiceBuilder) builder.overrides(overrides.toArray(new Binding[overrides.size()]));
+      return builder.injector().instanceOf(Application.class);
     }
 
     private TestServer buildTestServer(WithTestServer ts) {
-      FakeApplication fake = buildFakeApplication(ts.fakeApplication());
+      Application fake = buildFakeApplication(ts.fakeApplication());
       return Helpers.testServer(ts.port(), fake);
     }
   }
@@ -81,12 +123,9 @@ public class NGTests extends NGTestsBase implements IHookable {
 
     if (fa != null)
     {
-      FakeApplication app = reader.buildFakeApplication(fa);
-      Helpers.running(app, new Runnable() {
-        @Override
-        public void run() {
-          icb.runTestMethod(testResult);
-        }
+      Application app = reader.buildFakeApplication(fa);
+      Helpers.running(app, () -> {
+        icb.runTestMethod(testResult);
       });
 
     }
@@ -94,11 +133,9 @@ public class NGTests extends NGTestsBase implements IHookable {
     {
       TestServer server = reader.buildTestServer(ts);
       // TODO: parameterize WebDriver
-      Helpers.running(server, HTMLUNIT, new F.Callback<TestBrowser>() {
-        public void invoke(final TestBrowser browser) {
-          _testBrowser = browser;
-          icb.runTestMethod(testResult);
-        }
+      Helpers.running(server, HTMLUNIT, browser -> {
+        _testBrowser = browser;
+        icb.runTestMethod(testResult);
       });
     }
     else

--- a/helpers/src/main/java/com/linkedin/plugin/j/WithFakeApplication.java
+++ b/helpers/src/main/java/com/linkedin/plugin/j/WithFakeApplication.java
@@ -1,11 +1,11 @@
 // Copyright 2012 LinkedIn
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,15 +13,15 @@
 // limitations under the License.
 package com.linkedin.plugin.j;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-
 import java.lang.annotation.Target;
-import java.lang.annotation.ElementType;
 
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface WithFakeApplication {
   String path() default ".";
   Class withGlobal() default Object.class;
+  Class guiceBuilder() default Object.class;
 }

--- a/helpers/src/main/java/com/linkedin/plugin/j/WithFakeApplication.java
+++ b/helpers/src/main/java/com/linkedin/plugin/j/WithFakeApplication.java
@@ -24,4 +24,5 @@ public @interface WithFakeApplication {
   String path() default ".";
   Class withGlobal() default Object.class;
   Class guiceBuilder() default Object.class;
+  Class<? extends FakeApplicationFactory> appFactory() default FakeApplicationFactoryImpl.class;
 }

--- a/helpers/src/main/java/com/linkedin/plugin/s/FakeApplicationFactory.java
+++ b/helpers/src/main/java/com/linkedin/plugin/s/FakeApplicationFactory.java
@@ -1,0 +1,10 @@
+package com.linkedin.plugin.s;
+
+import play.api.Application;
+
+/**
+ * Knows how to build applications using the data that is available from annotations.
+ */
+public interface FakeApplicationFactory {
+  Application buildScalaApplication(FakeApplicationFactoryArgs args);
+}

--- a/helpers/src/main/java/com/linkedin/plugin/s/FakeApplicationFactoryArgs.java
+++ b/helpers/src/main/java/com/linkedin/plugin/s/FakeApplicationFactoryArgs.java
@@ -1,0 +1,57 @@
+package com.linkedin.plugin.s;
+
+import play.api.GlobalSettings;
+import play.api.inject.Binding;
+import play.api.inject.guice.GuiceBuilder;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeApplicationFactoryArgs {
+  private final File _path;
+  private final Optional<Class<? extends GuiceBuilder>> _builderClass;
+  private final Optional<GlobalSettings> _global;
+  private final List<Binding<?>> _overrides;
+  private final Map<String, Object> _config;
+  private final List<String> _plugins;
+
+  public FakeApplicationFactoryArgs(File path,
+                                    Optional<Class<? extends GuiceBuilder>> builderClass,
+                                    Optional<GlobalSettings> global,
+                                    List<Binding<?>> overrides,
+                                    Map<String, Object> config,
+                                    List<String> plugins) {
+    _path = path;
+    _builderClass = builderClass;
+    _global = global;
+    _overrides = overrides;
+    _config = config;
+    _plugins = plugins;
+  }
+
+  public File getPath() {
+    return _path;
+  }
+
+  public Optional<Class<? extends GuiceBuilder>> getBuilderClass() {
+    return _builderClass;
+  }
+
+  public Optional<GlobalSettings> getGlobal() {
+    return _global;
+  }
+
+  public List<Binding<?>> getOverrides() {
+    return _overrides;
+  }
+
+  public Map<String, Object> getConfig() {
+    return _config;
+  }
+
+  public List<String> getPlugins() {
+    return _plugins;
+  }
+}

--- a/helpers/src/main/java/com/linkedin/plugin/s/FakeApplicationFactoryImpl.java
+++ b/helpers/src/main/java/com/linkedin/plugin/s/FakeApplicationFactoryImpl.java
@@ -1,0 +1,70 @@
+package com.linkedin.plugin.s;
+
+import play.api.Application;
+import play.api.Environment;
+import play.api.GlobalSettings;
+import play.api.Mode;
+import play.api.inject.guice.GuiceApplicationBuilder;
+import play.api.inject.guice.GuiceBuilder;
+import play.api.inject.package$;
+import play.api.mvc.Handler;
+import play.api.test.FakeApplication;
+import play.api.test.Helpers;
+import play.libs.Scala;
+import scala.PartialFunction$;
+import scala.Tuple2;
+
+import java.util.Collections;
+
+/**
+ * Default implementation for building an Application. If a builder isn't specified and no overrides are present the Play
+ * FakeApplication is used. Otherwise a builder is used. Using @WithPlugins and a builder or overrides isn't supported.
+ */
+public class FakeApplicationFactoryImpl implements FakeApplicationFactory {
+  @Override
+  public Application buildScalaApplication(FakeApplicationFactoryArgs args) {
+    return shouldUseBuilder(args) ? buildFromBuilder(args) : buildFromFakeApp(args);
+  }
+
+  protected boolean shouldUseBuilder(FakeApplicationFactoryArgs args) {
+    return args.getBuilderClass().isPresent() || !args.getOverrides().isEmpty();
+  }
+
+  protected Application buildFromBuilder(FakeApplicationFactoryArgs args) {
+    Class<? extends GuiceBuilder> builderClass = args.getBuilderClass().orElse(GuiceApplicationBuilder.class);
+    GuiceBuilder builder;
+    try {
+      builder = builderClass.newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to instantiate application builder " + builderClass, e);
+    }
+    if (!args.getPlugins().isEmpty()) {
+      throw new RuntimeException("Using plugins isn't supported when using binding overrides or a GuiceBuilder.");
+    }
+    builder = (GuiceBuilder) builder.in(new Environment(args.getPath(), play.test.Helpers.class.getClassLoader(), Mode.Test()));
+    builder = (GuiceBuilder) builder.configure(Scala.asScala(args.getConfig()));
+    if (args.getGlobal().isPresent()) {
+      GlobalSettings global = args.getGlobal().get();
+      if (builder instanceof GuiceApplicationBuilder) {
+        builder = ((GuiceApplicationBuilder) builder).global(global);
+      } else {
+        builder = (GuiceBuilder) builder.bindings(Scala.varargs(package$.MODULE$.bind(play.api.GlobalSettings.class).toInstance(global)));
+      }
+    }
+    builder = (GuiceBuilder) builder.overrides(Scala.asScala(args.getOverrides()));
+    return builder.injector().instanceOf(Application.class);
+  }
+
+  protected Application buildFromFakeApp(FakeApplicationFactoryArgs args) {
+    return new FakeApplication(
+        args.getPath(),
+        Helpers.class.getClassLoader(),
+        Scala.toSeq(args.getPlugins()),
+        Scala.toSeq(Collections.<String>emptyList()),
+        Scala.asScala(args.getConfig()),
+        scala.Option.apply(args.getGlobal().orElse(null)),
+        PartialFunction$.MODULE$.<Tuple2<String, String>, Handler>empty()
+    );
+
+  }
+}

--- a/helpers/src/main/java/com/linkedin/plugin/s/NGTests.java
+++ b/helpers/src/main/java/com/linkedin/plugin/s/NGTests.java
@@ -17,28 +17,17 @@ import com.linkedin.plugin.NGTestsBase;
 import org.testng.IHookCallBack;
 import org.testng.IHookable;
 import org.testng.ITestResult;
-import play.api.Environment;
-import play.api.Mode;
 import play.api.Application;
 import play.api.GlobalSettings;
-import play.api.inject.Binding;
-import play.api.inject.guice.GuiceApplicationBuilder;
 import play.api.inject.guice.GuiceBuilder;
-import play.api.inject.package$;
-import play.api.mvc.Handler;
-import play.api.test.FakeApplication;
 import play.api.test.Helpers;
 import play.api.test.TestBrowser;
 import play.api.test.TestServer;
-import play.libs.Scala;
-import scala.PartialFunction$;
-import scala.Tuple2;
 import scala.runtime.AbstractFunction0;
 import scala.runtime.AbstractFunction1;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.List;
+import java.util.Optional;
 
 import static play.test.Helpers.HTMLUNIT;
 
@@ -57,55 +46,16 @@ public class NGTests extends NGTestsBase implements IHookable {
       if (fa == null) {
         return null;
       }
-      String path = fa.path();
-      GlobalSettings globalSettings = null;
-      if (isDefined(fa.withGlobal())) {
-        try {
-          globalSettings = (GlobalSettings) fa.withGlobal().newInstance();
-        } catch (Throwable e) {
-          throw new RuntimeException(e);
-        }
-      }
 
-      List<Binding<?>> overrides = getOverrides();
-      if (isDefined(fa.guiceBuilder()) || !overrides.isEmpty()) {
-        Class builderClass = Object.class.equals(fa.guiceBuilder()) ? GuiceApplicationBuilder.class : fa.guiceBuilder();
-        return buildFromBuilder(new File(path), globalSettings, builderClass, overrides);
-      }
-
-      // adapted from play.test.FakeApplication
-      return new FakeApplication(
-        new File(path),
-        Helpers.class.getClassLoader(),
-        Scala.toSeq(getPlugins()),
-        Scala.toSeq(Collections.<String>emptyList()),
-        Scala.asScala(getConf()),
-        scala.Option.apply(globalSettings),
-        PartialFunction$.MODULE$.<Tuple2<String, String>, Handler>empty()
-      );
-    }
-
-    private Application buildFromBuilder(File path, GlobalSettings globalSettings, Class builderClass, List<Binding<?>> overrides) {
-      GuiceBuilder builder;
-      try {
-        builder = (GuiceBuilder) builderClass.newInstance();
-      } catch (Exception e) {
-        throw new RuntimeException("Unable to instantiate application builder " + builderClass, e);
-      }
-      if (!getPlugins().isEmpty()) {
-        throw new RuntimeException("Using plugins isn't supported when using binding overrides or a GuiceBuilder.");
-      }
-      builder = (GuiceBuilder) builder.in(new Environment(path, play.test.Helpers.class.getClassLoader(), Mode.Test()));
-      builder = (GuiceBuilder) builder.configure(Scala.asScala(getConf()));
-      if (globalSettings != null) {
-        if (builder instanceof GuiceApplicationBuilder) {
-          builder = ((GuiceApplicationBuilder) builder).global(globalSettings);
-        } else {
-          builder = (GuiceBuilder) builder.bindings(Scala.varargs(package$.MODULE$.bind(play.api.GlobalSettings.class).toInstance(globalSettings)));
-        }
-      }
-      builder = (GuiceBuilder) builder.overrides(Scala.asScala(overrides));
-      return builder.injector().instanceOf(Application.class);
+      FakeApplicationFactory appFactory = instantiate(fa.appFactory());
+      return appFactory.buildScalaApplication(new FakeApplicationFactoryArgs(
+          new File(fa.path()),
+          isDefined(fa.guiceBuilder()) ? Optional.of(fa.guiceBuilder()) : Optional.<Class<? extends GuiceBuilder>>empty(),
+          isDefined(fa.withGlobal()) ? Optional.of(instantiate(fa.withGlobal())) : Optional.<GlobalSettings>empty(),
+          getOverrides(),
+          getConf(),
+          getPlugins()
+      ));
     }
 
     private TestServer buildTestServer(WithTestServer ts) {

--- a/helpers/src/main/java/com/linkedin/plugin/s/WithFakeApplication.java
+++ b/helpers/src/main/java/com/linkedin/plugin/s/WithFakeApplication.java
@@ -13,15 +13,15 @@
 // limitations under the License.
 package com.linkedin.plugin.s;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-
 import java.lang.annotation.Target;
-import java.lang.annotation.ElementType;
 
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface WithFakeApplication {
   String path() default ".";
   Class withGlobal() default Object.class;
+  Class guiceBuilder() default Object.class;
 }

--- a/helpers/src/main/java/com/linkedin/plugin/s/WithFakeApplication.java
+++ b/helpers/src/main/java/com/linkedin/plugin/s/WithFakeApplication.java
@@ -24,4 +24,5 @@ public @interface WithFakeApplication {
   String path() default ".";
   Class withGlobal() default Object.class;
   Class guiceBuilder() default Object.class;
+  Class<? extends FakeApplicationFactory> appFactory() default FakeApplicationFactoryImpl.class;
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,7 +20,8 @@ object NGPluginBuild extends Build {
     settings = commonSettings ++ Seq(
       libraryDependencies ++= Seq(
         "org.testng" % "testng" % "6.8.8", // % "provided"
-        "com.typesafe.play" %% "play-test" % "2.4.0" //% "provided"
+        "com.typesafe.play" %% "play-test" % "2.4.0", //% "provided"
+        "com.typesafe.play" %% "play-java" % "2.4.0" //% "provided"
       )))
 
   lazy val NGPlugin = Project(


### PR DESCRIPTION
Deprecated WithPlugins - using overrides or a specific builder will not use Play's FakeApplication, so it's not possible to use both WithPlugins and overrides or a builder.