### PR TITLE
Fix problem that skipped tests are recognized as successful

### DIFF
--- a/helpers/src/main/java/com/linkedin/plugin/FailSkippedTestsListener.java
+++ b/helpers/src/main/java/com/linkedin/plugin/FailSkippedTestsListener.java
@@ -8,7 +8,7 @@ import org.testng.TestListenerAdapter;
  *
  * This is a workaround for a bug in sbt testng plugin that skipped tests won't fail the entire test suite.
  */
-public class SkipTestListener extends TestListenerAdapter {
+public class FailSkippedTestsListener extends TestListenerAdapter {
 
   @Override
   public void onTestSkipped(ITestResult testResult) {

--- a/helpers/src/main/java/com/linkedin/plugin/SkipTestListener.java
+++ b/helpers/src/main/java/com/linkedin/plugin/SkipTestListener.java
@@ -1,0 +1,17 @@
+package com.linkedin.plugin;
+
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+
+/**
+ * Created by rli on 2/9/16.
+ *
+ * This is a workaround for a bug in sbt testng plugin that skipped tests won't fail the entire test suite.
+ */
+public class SkipTestListener extends TestListenerAdapter {
+
+  @Override
+  public void onTestSkipped(ITestResult testResult) {
+    testResult.setStatus(ITestResult.FAILURE);
+  }
+}

--- a/plugin/src/main/scala/NGPlugin.scala
+++ b/plugin/src/main/scala/NGPlugin.scala
@@ -39,6 +39,7 @@ object NGPlugin extends Plugin {
    ) ++
    testNGSettings ++
    Seq(
+     testNGParameters ++= Seq("-listener", "com.linkedin.plugin.SkipTestListener"),
        libraryDependencies <++= (testNGVersion)(v => Seq(
          "org.testng" % "testng" % v % "test->default",
          // If changing this, be sure to change in Build.scala also.

--- a/plugin/src/main/scala/NGPlugin.scala
+++ b/plugin/src/main/scala/NGPlugin.scala
@@ -39,7 +39,7 @@ object NGPlugin extends Plugin {
    ) ++
    testNGSettings ++
    Seq(
-     testNGParameters ++= Seq("-listener", "com.linkedin.plugin.SkipTestListener"),
+     testNGParameters ++= Seq("-listener", "com.linkedin.plugin.FailSkippedTestsListener"),
        libraryDependencies <++= (testNGVersion)(v => Seq(
          "org.testng" % "testng" % v % "test->default",
          // If changing this, be sure to change in Build.scala also.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -40,7 +40,7 @@ object NGPluginBuild extends Build {
   lazy val commonSettings: Seq[Setting[_]] = Project.defaultSettings ++ Seq(
     organization := "com.linkedin.play-testng-plugin",
     scalaVersion := "2.10.4",
-    version := "2.4.1",
+    version := "2.4.2",
     resolvers ++= Seq(Repos.typeSafeReleases, Repos.scalazReleases)
   )
 }


### PR DESCRIPTION
Tested with sample app. Manually throw exception in @BeforeClass and the final test result is failed as expected.