### PR TITLE
Remove unnecessary repos

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,11 +4,6 @@ import sbt.Keys._
 
 object NGPluginBuild extends Build {
 
-  object Repos {
-    val typeSafeReleases = "Typesafe Releases Repository" at "http://repo.typesafe.com/typesafe/releases/"
-    val scalazReleases = "Scalaz Repository" at "http://dl.bintray.com/scalaz/releases"
-  }
-
   lazy val root = Project("root", file("."),
     settings = commonSettings ++ Seq(
       name := "play-testng"
@@ -40,7 +35,6 @@ object NGPluginBuild extends Build {
   lazy val commonSettings: Seq[Setting[_]] = Project.defaultSettings ++ Seq(
     organization := "com.linkedin.play-testng-plugin",
     scalaVersion := "2.10.4",
-    version := "2.4.2",
-    resolvers ++= Seq(Repos.typeSafeReleases, Repos.scalazReleases)
+    version := "2.4.2"
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11


### PR DESCRIPTION
I don't believe that either of these repos are required. We should remove them because http repos introduce a security risk (see http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/)