### PR TITLE
Fix method not found error

### DIFF
--- a/plugin/src/main/scala/NGPlugin.scala
+++ b/plugin/src/main/scala/NGPlugin.scala
@@ -22,18 +22,6 @@ object NGPlugin extends Plugin {
 
   def ngSettings: Seq[Setting[_]] = super.settings ++ Seq(
     testOptions := Seq(),
-    testOptions += Tests.Setup { loader =>
-      val loggerClass = playLoggerClass(loader)
-      if (loggerClass != null) {
-        loggerClass.getMethod("init", classOf[java.io.File]).invoke(null, new java.io.File("."))
-      }
-    },
-    testOptions += Tests.Cleanup { loader =>
-      val loggerClass = playLoggerClass(loader)
-      if (loggerClass != null) {
-        loggerClass.getMethod("shutdown").invoke(null)
-      }
-    },
     //testOptions += Tests.Argument(TestFrameworks.Specs2, "sequential", "true"),
     testOptions += Tests.Argument(TestFrameworks.JUnit,"junitxml", "console")
    ) ++
@@ -45,12 +33,4 @@ object NGPlugin extends Plugin {
          // If changing this, be sure to change in Build.scala also.
          "de.johoop" %% "sbt-testng-interface" % "3.0.2" % "test"))
   )
-
-  private def playLoggerClass(loader: ClassLoader) = {
-    try {
-      loader.loadClass("play.api.Logger")
-    } catch {
-      case e: ClassNotFoundException => null
-    }
-  }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -35,6 +35,6 @@ object NGPluginBuild extends Build {
   lazy val commonSettings: Seq[Setting[_]] = Project.defaultSettings ++ Seq(
     organization := "com.linkedin.play-testng-plugin",
     scalaVersion := "2.10.4",
-    version := "2.4.2"
+    version := "2.4.3"
   )
 }


### PR DESCRIPTION
Play 2.4 changed the method signature of Logger.init(), and it failed. I can't think of a reason to initialize Play logger before test in the parent process. The parent process (sbt) doesn't need Play logger at all.