### PR TITLE
Remove unsupported Scala verions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val NGHelpers = (project in file("helpers"))
   .settings(
     name := "play-testng-helpers",
     scalaVersion := "2.11.11",
-    crossScalaVersions := Seq("2.11.11", "2.12.4"),
+    crossScalaVersions := Seq("2.11.11"),
     libraryDependencies ++= Seq(
       "org.testng" % "testng" % "6.8.8", // % "provided"
       "com.typesafe.play" %% "play-test" % "2.5.18", //% "provided"
@@ -23,7 +23,7 @@ lazy val NGPlugin = (project in file("plugin"))
     name := "play-plugins-testng",
     sbtPlugin := true,
     scalaVersion := "2.10.6",
-    crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.4"),
+    crossScalaVersions := Seq("2.10.6"),
     libraryDependencies ++= Seq(
         // If changing this, be sure to change in NGPlugin.scala also.
         sbtPluginExtra("de.johoop" % "sbt-testng-plugin" % "3.1.1", (sbtBinaryVersion in update).value, (scalaBinaryVersion in update).value),

--- a/sample/build.sbt
+++ b/sample/build.sbt
@@ -1,12 +1,11 @@
 import com.linkedin.plugin.NGPlugin
-import de.johoop.testngplugin.TestNGPlugin
 
 lazy val root = (project in file("."))
   .settings(
     name := "Sample",
     version := "2.5.0-SNAPSHOT",
     scalaVersion := "2.11.11",
-    crossScalaVersions := Seq("2.11.11", "2.12.4"),
+    crossScalaVersions := Seq("2.11.11"),
     libraryDependencies ++= Seq(
       "com.linkedin.play-testng-plugin" %% "play-testng-helpers" % "2.5.0"
     )


### PR DESCRIPTION
Play 2.5's libraries only support Scala 2.11. Play 2.5's sbt plugins only support Scala 2.10.